### PR TITLE
请升级com.google.protobuf:protobuf-java组件版本以解决3个安全漏洞

### DIFF
--- a/oap-server-bom/pom.xml
+++ b/oap-server-bom/pom.xml
@@ -41,8 +41,7 @@
         <zookeeper.version>3.5.7</zookeeper.version>
         <guava.version>31.1-jre</guava.version>
         <snakeyaml.version>1.32</snakeyaml.version>
-        <protobuf-java.version>3.19.4</protobuf-java.version>
-        <protobuf-java-util.version>3.19.4</protobuf-java-util.version>
+        <protobuf-java.version>3.20.0-rc-1</protobuf-java.version>    <protobuf-java-util.version>3.19.4</protobuf-java-util.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-io.version>2.7</commons-io.version>


### PR DESCRIPTION
通过murphysec.com提交PR来修复安全漏洞